### PR TITLE
Update recipe doc link and maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,9 +40,10 @@ about:
   license_family: BSD
   license_file: LICENSE.md
   summary: 'Synthetic photometry package from Astrolib.'
-  doc_url: https://github.com/spacetelescope/pysynphot/tree/master/doc
+  doc_url: https://pysynphot.readthedocs.io
   dev_url: https://github.com/spacetelescope/pysynphot
 
 extra:
   recipe-maintainers:
     - mfisherlevine
+    - pllim


### PR DESCRIPTION
This is just to update maintainers and doc link in the recipe as discussed in conda-forge/staged-recipes#15991 . I do not think a new "release" to conda-forge is necessary, as it does not affect the actual package functionality.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
